### PR TITLE
Add support for debugging cassettes with HexDebug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id "fabric-loom" version "1.6-SNAPSHOT"
+	id "fabric-loom" version "1.7-SNAPSHOT"
 	id "maven-publish"
 	id "org.jetbrains.kotlin.jvm" version "1.8.0"
 }
@@ -34,8 +34,10 @@ dependencies {
 		exclude module: "lithium"
 		exclude module: "emi"
 	}
+	modImplementation(include("gay.object.hexdebug:hexdebug-core-fabric:$hexdebug_version+$minecraft_version"))
 
 	modLocalRuntime "dev.onyxstudios.cardinal-components-api:cardinal-components-api:$cardinal_components_version"
+	modLocalRuntime "gay.object.hexdebug:hexdebug-fabric:$hexdebug_version+$minecraft_version"
 	modLocalRuntime "com.samsthenerd.inline:inline-fabric:$minecraft_version-$inline_version"
 	modLocalRuntime "vazkii.patchouli:Patchouli:$minecraft_version-$patchouli_version-FABRIC"
 	modLocalRuntime "at.petra-k.paucal:paucal-fabric-$minecraft_version:$paucal_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ cloth_config_version = 11.1.118
 fabric_api_version = 0.92.2+1.20.1
 fabric_kotlin_version = 1.10.10+kotlin.1.9.10
 hexcasting_version = 0.11.2-pre-702
+hexdebug_version = 0.8.0
 hexpose_version = 1.0.0
 inline_version = 1.0.2-51
 patchouli_version = 84

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/miyucomics/hexcassettes/actions/OpEnqueue.kt
+++ b/src/main/java/miyucomics/hexcassettes/actions/OpEnqueue.kt
@@ -15,10 +15,13 @@ import at.petrak.hexcasting.api.casting.mishaps.MishapBadCaster
 import at.petrak.hexcasting.api.casting.mishaps.MishapInvalidIota
 import at.petrak.hexcasting.api.casting.mishaps.MishapNotEnoughArgs
 import at.petrak.hexcasting.common.lib.hex.HexEvalSounds
+import gay.`object`.hexdebug.core.api.HexDebugCoreAPI
+import gay.`object`.hexdebug.core.api.exceptions.DebugException
 import miyucomics.hexcassettes.CassetteCastEnv
 import miyucomics.hexcassettes.HexcassettesMain
 import miyucomics.hexcassettes.PlayerEntityMinterface
 import miyucomics.hexcassettes.data.QueuedHex
+import miyucomics.hexcassettes.interop.hexdebug.CassetteDebugEnv
 import miyucomics.hexpose.iotas.TextIota
 import net.minecraft.text.Text
 import net.minecraft.util.DyeColor
@@ -33,14 +36,31 @@ class OpEnqueue : Action {
 		val cassetteState = (env.castingEntity as PlayerEntityMinterface).getCassetteState()
 
 		val stack = image.stack.toMutableList()
-		var key = if (env is CassetteCastEnv && !cassetteState.hexes.containsKey(env.key))
-			env.key
-		else
-			Text.Serializer.toJson(PatternIota.display(EulerPathFinder.findAltDrawing(HexPattern.fromAngles("qeqwqwqwqwqeqaweqqqqqwweeweweewqdwwewewwewweweww", HexDir.EAST), env.world.time)))
-		var labelled = 0
-		if (stack.last() is TextIota) {
-			key = Text.Serializer.toJson((stack.removeLast() as TextIota).text)
-			labelled++
+
+		val key: String
+		val keyText: Text
+		val labelled: Int
+		when {
+			// get key from stack
+			stack.last() is TextIota -> {
+				keyText = (stack.removeLast() as TextIota).text
+				key = Text.Serializer.toJson(keyText)
+				labelled = 1
+			}
+
+			// get key from current cassette
+			env is CassetteCastEnv && !cassetteState.hexes.containsKey(env.key) -> {
+				key = env.key
+				keyText = Text.Serializer.fromJson(key)!!
+				labelled = 0
+			}
+
+			// generate random key
+			else -> {
+				keyText = PatternIota.display(EulerPathFinder.findAltDrawing(HexPattern.fromAngles("qeqwqwqwqwqeqaweqqqqqwweeweweewqdwwewewwewweweww", HexDir.EAST), env.world.time))
+				key = Text.Serializer.toJson(keyText)
+				labelled = 0
+			}
 		}
 
 		val potentialDelay = stack.removeLast()
@@ -57,10 +77,22 @@ class OpEnqueue : Action {
 		var depth = 0
 		if (env is CassetteCastEnv && env.depth < 10)
 			depth = env.depth + 1
-		cassetteState.hexes[key] = QueuedHex(IotaType.serialize(potentialHex), potentialDelay.double.toInt(), depth)
+
+		val queuedHex = QueuedHex(IotaType.serialize(potentialHex), potentialDelay.double.toInt(), depth)
+
+		// if the current cast is being debugged, try to create the cassette in debug mode too
+		if (HexDebugCoreAPI.INSTANCE.getDebugEnv(env) != null) {
+			val debugEnv = CassetteDebugEnv(env.caster!!, key, keyText, queuedHex)
+			try {
+				HexDebugCoreAPI.INSTANCE.createDebugThread(debugEnv, null)
+				queuedHex.debugSessionId = debugEnv.sessionId
+			} catch (_: DebugException) {}
+		}
+
+		cassetteState.hexes[key] = queuedHex
 
 		if (labelled == 0)
-			stack.add(TextIota(Text.Serializer.fromJson(key)!!))
+			stack.add(TextIota(keyText))
 		return OperationResult(image.copy(stack = stack), listOf(), continuation, HexEvalSounds.SPELL)
 	}
 }

--- a/src/main/java/miyucomics/hexcassettes/data/CassetteState.kt
+++ b/src/main/java/miyucomics/hexcassettes/data/CassetteState.kt
@@ -1,5 +1,6 @@
 package miyucomics.hexcassettes.data
 
+import gay.`object`.hexdebug.core.api.HexDebugCoreAPI
 import miyucomics.hexcassettes.inits.HexcassettesNetworking
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking
@@ -30,6 +31,8 @@ class CassetteState {
 			if (hex.delay <= 0) {
 				iterator.remove()
 				hex.cast(player, pattern)
+			} else if (!hex.stillValid(player)) {
+				iterator.remove()
 			}
 		}
 

--- a/src/main/java/miyucomics/hexcassettes/data/QueuedHex.kt
+++ b/src/main/java/miyucomics/hexcassettes/data/QueuedHex.kt
@@ -1,33 +1,58 @@
 package miyucomics.hexcassettes.data
 
+import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
 import at.petrak.hexcasting.api.casting.eval.vm.CastingVM
 import at.petrak.hexcasting.api.casting.iota.IotaType
 import at.petrak.hexcasting.api.casting.iota.ListIota
 import at.petrak.hexcasting.api.utils.putCompound
+import gay.`object`.hexdebug.core.api.HexDebugCoreAPI
 import miyucomics.hexcassettes.CassetteCastEnv
 import net.minecraft.nbt.NbtCompound
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.util.Hand
+import java.util.*
 
-data class QueuedHex(val hex: NbtCompound, var delay: Int, val depth: Int = 10) {
+data class QueuedHex(val hex: NbtCompound, var delay: Int, val depth: Int = 10, var debugSessionId: UUID? = null) {
 	fun serialize(): NbtCompound {
 		val compound = NbtCompound()
 		compound.putCompound("hex", hex)
 		compound.putInt("delay", delay)
 		compound.putInt("depth", depth)
+		debugSessionId?.let { compound.putUuid("debugSessionId", it) }
 		return compound
 	}
 
 	fun cast(player: ServerPlayerEntity, key: String) {
 		val hand = if (!player.getStackInHand(Hand.MAIN_HAND).isEmpty && player.getStackInHand(Hand.OFF_HAND).isEmpty) Hand.OFF_HAND else Hand.MAIN_HAND
-		val harness = CastingVM.empty(CassetteCastEnv(player, hand, key, depth))
-		val hexIota = IotaType.deserialize(hex, player.serverWorld)
-		if (hexIota is ListIota)
-			harness.queueExecuteAndWrapIotas(hexIota.list.toList(), player.serverWorld)
+		val env = CassetteCastEnv(player, hand, key, depth)
+		val image = CastingImage()
+
+		val hexIota = IotaType.deserialize(hex, player.serverWorld) as? ListIota ?: return
+		val iotas = hexIota.list.toList()
+
+		if (debugSessionId == null) {
+			// cast normally
+			CastingVM(image, env).queueExecuteAndWrapIotas(iotas, player.serverWorld)
+		} else {
+			// try to start debugging, or fail silently if the debug session no longer exists
+			debugSessionId
+				?.let { HexDebugCoreAPI.INSTANCE.getDebugEnv(player, it) }
+				?.let { HexDebugCoreAPI.INSTANCE.startDebuggingIotas(it, env, iotas, image) }
+		}
 	}
+
+	// if we have a debug session id but HexDebug doesn't know about it, the debug session has been terminated
+	// so cancel the cassette immediately
+	fun stillValid(player: ServerPlayerEntity) =
+		debugSessionId == null || HexDebugCoreAPI.INSTANCE.getDebugEnv(player, debugSessionId!!) != null
 
 	companion object {
 		fun deserialize(compound: NbtCompound) =
-			QueuedHex(compound.getCompound("hex"), compound.getInt("delay"), compound.getInt("depth"))
+			QueuedHex(
+				compound.getCompound("hex"),
+				compound.getInt("delay"),
+				compound.getInt("depth"),
+				if (compound.contains("debugSessionId")) compound.getUuid("debugSessionId") else null,
+			)
 	}
 }

--- a/src/main/java/miyucomics/hexcassettes/interop/hexdebug/CassetteDebugEnv.kt
+++ b/src/main/java/miyucomics/hexcassettes/interop/hexdebug/CassetteDebugEnv.kt
@@ -1,0 +1,32 @@
+package miyucomics.hexcassettes.interop.hexdebug
+
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.eval.ResolvedPatternType
+import at.petrak.hexcasting.api.casting.eval.vm.CastingImage
+import gay.`object`.hexdebug.core.api.HexDebugCoreAPI
+import gay.`object`.hexdebug.core.api.debugging.env.DebugEnvironment
+import miyucomics.hexcassettes.data.QueuedHex
+import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.text.Text
+
+class CassetteDebugEnv(
+    caster: ServerPlayerEntity,
+    private val key: String,
+    private val keyText: Text,
+    private val queuedHex: QueuedHex,
+) : DebugEnvironment(caster) {
+    override fun resume(env: CastingEnvironment, image: CastingImage, resolutionType: ResolvedPatternType): Boolean {
+        return false
+    }
+
+    override fun restart(threadId: Int) {
+        HexDebugCoreAPI.INSTANCE.createDebugThread(this, threadId)
+        queuedHex.cast(caster, key)
+    }
+
+    override fun terminate() {}
+
+    override fun isCasterInRange() = true
+
+    override fun getName() = keyText
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,5 +37,8 @@
 		"fabric-api": "*",
 		"fabric-language-kotlin": ">=1.10.10+kotlin.1.9.10",
 		"hexcasting": ">=0.11.1-7-pre-646"
+	},
+	"suggests": {
+		"hexdebug": ">=0.8.0+1.20.1"
 	}
 }


### PR DESCRIPTION
This PR adds optional support for HexDebug's new [debug environment API](https://hexdebug.hexxy.media/v/0.8.0+1.20.1/1.1/api/hexdebug-core-common/index.html).

Cassettes will automatically be enqueued in debug mode if all of the following conditions are met:
- The casting environment that created the cassettes is in debug mode, eg. cast by a Debugger.
- The player associated with the parent environment is enlightened.
- The player associated with the parent environment has at least one debug thread not currently in use.

To simplify the implementation, HexDebug Core will be bundled in Hexcassettes via Jar-in-Jar. This means anything from the `gay.object.hexdebug.core.api` package can be safely accessed without first checking if HexDebug is loaded or not.

To allow running the dev environment with HexDebug present, it was also necessary to bump the minimum required versions of Gradle and Fabric Loom.